### PR TITLE
R&Y: Converted Arcade Data Card list into table format

### DIFF
--- a/flip-wiki/docs/arcadecards.md
+++ b/flip-wiki/docs/arcadecards.md
@@ -1,23 +1,24 @@
 ## Arcade Data Cards
+> ⚠️ ***You __should not__ be using your Flipper Zero to emulate your arcade data card.*** ⚠️
+
 There are five main arcade data cards that are used in arcades; they are:
-> - Andamiro's [AM.PASS](https://am-pass.net/) [ISO15693-3 SLI/SLIX/SLIX2];
-> 
-> - Bandai Namco's [Bandai Namco Passport](https://banapass.net/setlocale/en) *fka Banapassport* [MIFARE Classic]
-> 
-> - Konami's [e-amusement pass](https://p.eagate.573.jp/index.html) [ISO15693-3 SLI/SLIX/SLIX2]
-> 
-> - Sega's [Aime Card](https://my-aime.net/en/) [MIFARE Classic]
-> 
-> - Taito's [NESiCA](https://nesica.net/) [MIFARE Ultralight]
 
-If you are after the `Sega Aime Card` or `Bandai Namco Passport` access keys, then they are included in the Flipper Zero's system dictionary as of OFW 0.98.2, with the `Sega Aime Card` having a parser that reveals your access code; you may want to copy/paste the access keys into your user dictionary *if you frequently find yourself using them*.
+| Company | Card | Chip | Notable Games |
+| ------------ | ------------- | ------------ | ------------ |
+| **Andamiro** | [AM.PASS](https://am-pass.net/) | ICODE SLI/SLIX/SLIX2 | [Chrono Circle](https://chrono-circle.com/) / [PIU](https://piugame.com/) |
+| **Bandai Namco** | [Bandai Namco Passport](https://banapass.net/setlocale/en/) | MIFARE Classic | [Taiko](https://donderhiroba.jp/login.php) / [WM6RR](https://wanganmaxi-official.com/wanganmaxi6rr/en/) |
+| **Konami** | [e-amusement pass](https://p.eagate.573.jp/index.html)| ICODE SLI/SLIX/SLIX2 | [DDR](https://p.eagate.573.jp/game/ddr/ddrworld/top/index.html) / [SDVX](https://p.eagate.573.jp/game/sdvx/vi/) |
+| **Sega** | [Aime](https://my-aime.net/en/) | MIFARE Classic | [IDAC](https://initiald.sega.jp/inidac/) / [maimai](https://maimai.sega.com/) |
+| **Taito** | [NESiCA](https://nesica.net/) | MIFARE Ultralight | [MUSiCDiVER](https://musicdiver.jp/index.html) / [SF6TA](https://sf6ta.jp/) |
 
-The latter four companies have cards endorsed with the `Amusement IC Card [AIC]` logo; these cards are FeliCa, and are interoperable with each others' games.
+If you are after the `Sega Aime` or `Bandai Namco Passport` access keys, then they are included in the Flipper Zero's system dictionary as of OFW 0.98.2, with the `Sega Aime` having a parser that reveals your access code; you may want to copy/paste the access keys into your user dictionary *if you frequently find yourself using them*.
 
-The Flipper Zero has expanded its *FeliCa* emulation support as of OFW 0.103.1; however, `Bandai Namco Passport` readers do not recognise the emulated AIC Card and `Sega Aime Card` readers fail to read the AIC Card.
+The latter four companies have cards endorsed with the `Amusement IC Card [AIC]` logo; these cards are `FeliCa`, and are *generally* compatible with each others' games.
+
+The Flipper Zero has expanded its `FeliCa` emulation support as of OFW 0.103.1; however, `Bandai Namco Passport` readers do not recognise the emulated `AIC Card`, and `Sega Aime Card` readers fail to read the `AIC Card`.
 ## Arcade Payment Cards
 > ⚠️ ***You __should not__ be using your Flipper Zero to emulate your arcade payment card.*** ⚠️
 
-If you are wanting to emulate your cashless pre-paid arcade payment card, then please check whether your arcade uses `Embed`; if they do, they may already have the `MobileWallet` module provisioned, meaning you may be able to legitimately add it to your `Apple Wallet` / `Google Wallet` via the arcade's Member Portal or App *provided your phone/watch/device is able to emulate NFC cards*.
+If you are wanting to emulate your cashless pre-paid arcade payment card, then please check whether your arcade uses `Embed`; if they do, they may already have the `MobileWallet` module provisioned, meaning you may be able to legitimately add your card to your `Apple Wallet` / `Google Wallet` via the arcade's Member Portal or App *provided your phone/watch/device is able to emulate NFC cards*.
 
-If your arcade otherwise uses `InterCard`, `Sacoa`, `Amusement Connect`, `Semnox`, `RFPay`, `Tigapo`, or another cashless arcade payment system, then please read the above warning.
+If your arcade otherwise uses `Amusement Connect`, `InterCard`, `RFPay`, `Sacoa`, `Semnox`, `Tigapo`, or another cashless arcade payment system, then please read the above warning.


### PR DESCRIPTION
Converted Arcade Data Card list into table format.
Gave examples of games that use each card
Correct nomeclature of the `Sega Aime`.
Added warning to the Arcade Data Card section.
Other formatting updates.

Many thanks in advance, and kind regards,

Randy.