### PR TITLE
R&Y: Replaced Arcade Payment Card section with mermaid flowchart

### DIFF
--- a/flip-wiki/docs/arcadecards.md
+++ b/flip-wiki/docs/arcadecards.md
@@ -29,9 +29,9 @@ flowchart TD
     C -->|Apple Wallet| E[My Arcade Uses...]
     C -->|Google Wallet| E
     E -->|Embed| F(Login to Arcade's App/Member Portal.)
-    F -->|Add Card to Wallet| G[Emulate Card via Wallet.]
+    F -->|Add Card to Wallet| G{Emulate Card via Wallet.}
     E -->|Other| H(Which System?)
-    B -->|No| I[PHONE EMULATION NOT POSSIBLE. DO NOT USE YOUR FLIPPER ZERO.]
+    B -->|No| I{PHONE EMULATION NOT POSSIBLE. DO NOT USE YOUR FLIPPER ZERO.}
     C -->|Other Wallet| I
     H -->|Amusement Connect| I
     H -->|InterCard| I

--- a/flip-wiki/docs/arcadecards.md
+++ b/flip-wiki/docs/arcadecards.md
@@ -23,21 +23,21 @@ The Flipper Zero has expanded its `FeliCa` emulation support as of OFW 0.103.1; 
 ``` mermaid
 flowchart TD
     A[I Want to Emulate my Cashless Pre-Paid Arcade Payment Card.] -->|Check Phone| B[NFC-Capable Phone?]
-    B -->|Yes: Enabled| C[I Use...]
+    B -->|No| I{PHONE EMULATION NOT POSSIBLE. DO NOT USE YOUR FLIPPER ZERO.}
     B -->|Yes: Disabled| D(Enable NFC.)
     D -->|NFC Enabled| C
+    B -->|Yes: Enabled| C[I Use...]
     C -->|Apple Wallet| E[My Arcade Uses...]
     C -->|Google Wallet| E
+    C -->|Other Wallet| I
     E -->|Embed| F(Login to Arcade's App/Member Portal.)
     F -->|Add Card to Wallet| G{Emulate Card via Wallet.}
     E -->|Other| H(Which System?)
-    B -->|No| I{PHONE EMULATION NOT POSSIBLE. DO NOT USE YOUR FLIPPER ZERO.}
-    C -->|Other Wallet| I
     H -->|Amusement Connect| I
-    H -->|InterCard| I
-    H -->|RFPay| I
+    H -->|intercard| I
+    H -->|Parafait| I
+    H -->|RFpay| I
     H -->|Sacoa| I
-    H -->|Semnox| I
     H -->|Tigapo| I
     H -->|Other| I
 ```

--- a/flip-wiki/docs/arcadecards.md
+++ b/flip-wiki/docs/arcadecards.md
@@ -28,15 +28,16 @@ flowchart TD
     D -->|NFC Enabled| C
     C -->|Apple Wallet| E[My Arcade Uses...]
     C -->|Google Wallet| E
-    E -->|Embed| H(Login to Arcade's App/Member Portal.)
-    H -->|Add Card to Wallet| I[Emulate Card via Wallet.]
-    B -->|No| Z[PHONE EMULATION NOT POSSIBLE. DO NOT USE YOUR FLIPPER ZERO.]
-    C -->|Other Wallet| Z
-    E -->|Amusement Connect| Z
-    E -->|InterCard| Z
-    E -->|RFPay| Z
-    E -->|Sacoa| Z
-    E -->|Semnox| Z
-    E -->|Tigapo| Z
-    E -->|Other| Z
+    E -->|Embed| F(Login to Arcade's App/Member Portal.)
+    F -->|Add Card to Wallet| G[Emulate Card via Wallet.]
+    E -->|Other| H(Which System?)
+    B -->|No| I[PHONE EMULATION NOT POSSIBLE. DO NOT USE YOUR FLIPPER ZERO.]
+    C -->|Other Wallet| I
+    H -->|Amusement Connect| I
+    H -->|InterCard| I
+    H -->|RFPay| I
+    H -->|Sacoa| I
+    H -->|Semnox| I
+    H -->|Tigapo| I
+    H -->|Other| I
 ```

--- a/flip-wiki/docs/arcadecards.md
+++ b/flip-wiki/docs/arcadecards.md
@@ -23,21 +23,16 @@ The Flipper Zero has expanded its `FeliCa` emulation support as of OFW 0.103.1; 
 ``` mermaid
 flowchart TD
     A[I Want to Emulate my Cashless Pre-Paid Arcade Payment Card.] -->|Check Phone| B[NFC-Capable Phone?]
-    B -->|No| I{PHONE EMULATION NOT POSSIBLE. DO NOT USE YOUR FLIPPER ZERO.}
+    B -->|No| H{PHONE EMULATION NOT POSSIBLE. DO NOT USE YOUR FLIPPER ZERO.}
     B -->|Yes: Disabled| D(Enable NFC.)
     D -->|NFC Enabled| C
     B -->|Yes: Enabled| C[I Use...]
     C -->|Apple Wallet| E[My Arcade Uses...]
     C -->|Google Wallet| E
-    C -->|Other Wallet| I
+    C -->|Other Wallet| H
     E -->|Embed| F(Login to Arcade's App/Member Portal.)
     F -->|Add Card to Wallet| G{Emulate Card via Wallet.}
-    E -->|Other| H(Which System?)
-    H -->|Amusement Connect| I
-    H -->|intercard| I
-    H -->|Parafait| I
-    H -->|RFpay| I
-    H -->|Sacoa| I
-    H -->|Tigapo| I
-    H -->|Other| I
+    E -->|Other| H
 ```
+!!! note "**LIST OF OTHER CASHLESS PRE-PAID ARCADE PAYMENT CARDS**"
+    Amusement Connect; intercard; Parafait; RFpay; Sacoa; Tigapo 

--- a/flip-wiki/docs/arcadecards.md
+++ b/flip-wiki/docs/arcadecards.md
@@ -27,8 +27,7 @@ flowchart TD
     B -->|Yes: Disabled| D(Enable NFC.)
     D -->|NFC Enabled| C
     B -->|Yes: Enabled| C[I Use...]
-    C -->|Apple Wallet| E[My Arcade Uses...]
-    C -->|Google Wallet| E
+    C -->|Apple Wallet / Google Wallet| E[My Arcade Uses...]
     C -->|Other Wallet| H
     E -->|Embed| F(Login to Arcade's App/Member Portal.)
     F -->|Add Card to Wallet| G{Emulate Card via Wallet.}

--- a/flip-wiki/docs/arcadecards.md
+++ b/flip-wiki/docs/arcadecards.md
@@ -32,7 +32,7 @@ flowchart TD
     C -->|Other Wallet| H
     E -->|Embed| F(Login to Arcade's App/Member Portal.)
     F -->|Add Card to Wallet| G{Emulate Card via Wallet.}
-    E -->|Other| H
+    E -->|Other System| H
 ```
 !!! note "**LIST OF OTHER CASHLESS PRE-PAID ARCADE PAYMENT CARDS**"
     Amusement Connect; intercard; Parafait; RFpay; Sacoa; Tigapo 

--- a/flip-wiki/docs/arcadecards.md
+++ b/flip-wiki/docs/arcadecards.md
@@ -1,24 +1,42 @@
 ## Arcade Data Cards
-> ⚠️ ***You __should not__ be using your Flipper Zero to emulate your arcade data card.*** ⚠️
+!!! warning "**WARNING**"
+    *You __should not__ be using your Flipper Zero to emulate your arcade data card.*
 
-There are five main arcade data cards that are used in arcades; they are:
+The five main arcade data cards are:
 
 | Company | Card | Chip | Notable Games |
 | ------------ | ------------- | ------------ | ------------ |
 | **Andamiro** | [AM.PASS](https://am-pass.net/) | ICODE SLI/SLIX/SLIX2 | [Chrono Circle](https://chrono-circle.com/) / [PIU](https://piugame.com/) |
 | **Bandai Namco** | [Bandai Namco Passport](https://banapass.net/setlocale/en/) | MIFARE Classic | [Taiko](https://donderhiroba.jp/login.php) / [WM6RR](https://wanganmaxi-official.com/wanganmaxi6rr/en/) |
-| **Konami** | [e-amusement pass](https://p.eagate.573.jp/index.html)| ICODE SLI/SLIX/SLIX2 | [DDR](https://p.eagate.573.jp/game/ddr/ddrworld/top/index.html) / [SDVX](https://p.eagate.573.jp/game/sdvx/vi/) |
+| **Konami** | [e-amusement pass](https://p.eagate.573.jp/index.html)| ICODE SLI | [DDR](https://p.eagate.573.jp/game/ddr/ddrworld/top/index.html) / [SDVX](https://p.eagate.573.jp/game/sdvx/vi/) |
 | **Sega** | [Aime](https://my-aime.net/en/) | MIFARE Classic | [IDAC](https://initiald.sega.jp/inidac/) / [maimai](https://maimai.sega.com/) |
 | **Taito** | [NESiCA](https://nesica.net/) | MIFARE Ultralight | [MUSiCDiVER](https://musicdiver.jp/index.html) / [SF6TA](https://sf6ta.jp/) |
 
-If you are after the `Sega Aime` or `Bandai Namco Passport` access keys, then they are included in the Flipper Zero's system dictionary as of OFW 0.98.2, with the `Sega Aime` having a parser that reveals your access code; you may want to copy/paste the access keys into your user dictionary *if you frequently find yourself using them*.
+The Flipper Zero includes the `Sega Aime` and `Bandai Namco Passport` access keys in the system dictionary as of OFW 0.98.2, with the `Sega Aime` parser for revealing the corresponding access code.
 
-The latter four companies have cards endorsed with the `Amusement IC Card [AIC]` logo; these cards are `FeliCa`, and are *generally* compatible with each others' games.
+The latter four companies have cards endorsed with the `Amusement IC Card [AIC]` logo; these cards instead use `FeliCa` chips, and are *generally* compatible for use with each others' games.
 
-The Flipper Zero has expanded its `FeliCa` emulation support as of OFW 0.103.1; however, `Bandai Namco Passport` readers do not recognise the emulated `AIC Card`, and `Sega Aime Card` readers fail to read the `AIC Card`.
+The Flipper Zero has expanded its `FeliCa` emulation support as of OFW 0.103.1; however: `Bandai Namco Passport` readers do not recognise the emulated `AIC Card`, and `Sega Aime Card` readers fail to read the `AIC Card`.
 ## Arcade Payment Cards
-> ⚠️ ***You __should not__ be using your Flipper Zero to emulate your arcade payment card.*** ⚠️
-
-If you are wanting to emulate your cashless pre-paid arcade payment card, then please check whether your arcade uses `Embed`; if they do, they may already have the `MobileWallet` module provisioned, meaning you may be able to legitimately add your card to your `Apple Wallet` / `Google Wallet` via the arcade's Member Portal or App *provided your phone/watch/device is able to emulate NFC cards*.
-
-If your arcade otherwise uses `Amusement Connect`, `InterCard`, `RFPay`, `Sacoa`, `Semnox`, `Tigapo`, or another cashless arcade payment system, then please read the above warning.
+!!! warning "**WARNING**"
+    *You __should not__ be using your Flipper Zero to emulate your arcade data card.*
+``` mermaid
+flowchart TD
+    A[I Want to Emulate my Cashless Pre-Paid Arcade Payment Card.] -->|Check Phone| B[NFC-Capable Phone?]
+    B -->|Yes: Enabled| C[I Use...]
+    B -->|Yes: Disabled| D(Enable NFC.)
+    D -->|NFC Enabled| C
+    C -->|Apple Wallet| E[My Arcade Uses...]
+    C -->|Google Wallet| E
+    E -->|Embed| H(Login to Arcade's App/Member Portal.)
+    H -->|Add Card to Wallet| I[Emulate Card via Wallet.]
+    B -->|No| Z[PHONE EMULATION NOT POSSIBLE. DO NOT USE YOUR FLIPPER ZERO.]
+    C -->|Other Wallet| Z
+    E -->|Amusement Connect| Z
+    E -->|InterCard| Z
+    E -->|RFPay| Z
+    E -->|Sacoa| Z
+    E -->|Semnox| Z
+    E -->|Tigapo| Z
+    E -->|Other| Z
+```

--- a/flip-wiki/docs/arcadecards.md
+++ b/flip-wiki/docs/arcadecards.md
@@ -27,7 +27,7 @@ flowchart TD
     B -->|Yes: Disabled| D(Enable NFC.)
     D -->|NFC Enabled| C
     B -->|Yes: Enabled| C[I Use...]
-    C -->|Apple Wallet / Google Wallet| E[My Arcade Uses...]
+    C -->|Apple/Google Wallet| E[My Arcade Uses...]
     C -->|Other Wallet| H
     E -->|Embed| F(Login to Arcade's App/Member Portal.)
     F -->|Add Card to Wallet| G{Emulate Card via Wallet.}


### PR DESCRIPTION
Replaced `Arcade Payment Card` section with a mermaid flowchart.
Multiple commits were made because of minute changes to the flowchart's layout.
Card systems were updated to use their correct name/styling.

Many thanks in advance, and kind regards,

Randy.