### PR TITLE
R&Y: Various Updates to Several `.md`s

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,11 @@ Please be sure submissions meet the [contribution guidelines](https://flipper.wi
 This wiki is built using the python based mkdocs builder utilizing the material theme (mkdocs-material).
 
 It is recommended, but not required, that contributors looking to add content run the wiki locally to verify formatting behaves as expected before submitting a pull request to verify the content looks as expected and ensure a smooth pull request process.
-To do so, you will need either a copy of [Git](https://git-scm.com/downloads) or the [Github client](https://github.com/apps/desktop) installed to your PC. 
+To do so, you will need either a copy of [Git](https://git-scm.com/downloads) or the [GitHub client](https://github.com/apps/desktop) installed to your PC. 
 
-You will then need to fork this repo using the fork button on this Github page to your own Github account, clone it to to your PC, make changes, then submit a Pull Request. 
+You will then need to fork this repo using the fork button on this GitHub page to your own GitHub account, clone it to to your PC, make changes, then submit a Pull Request. 
 
-#### If you are unfamiliar with using git and making pull requests on Github, see the [Pull Request Guide](pull-request-guide.md)
+#### If you are unfamiliar with using git and making pull requests on GitHub, see the [Pull Request Guide](pull-request-guide.md)
 
 # Setup Guide: Running this Wiki Locally
 
@@ -31,7 +31,7 @@ For this, we will use the awesome tiny [uv](https://astral.sh) utility to manage
 1. run `winget install astral-sh.uv`
 1. Hit yes on any prompts, and wait for the install to finish. 
 1. close and re-open Powershell. 
-1. Using git or the Github client, clone your fork of the docs to your PC. 
+1. Using git or the GitHub client, clone your fork of the docs to your PC. 
 1. In Powershell, `cd` into the `flipper-community-wiki\flip-wiki` folder that you got from cloning your fork onto your PC. 
 1. simply run `uvx --from mkdocs-material mkdocs serve` to launch mkdocs seamlessly without installing anything to your PC.
     - Note: the tool will say `warning: An executable named mkdocs is not provided(...)`, you can safely disregard this, as mkdocs-material just looks odd the way its set up to this utility.  
@@ -84,7 +84,7 @@ This method wil directly install MkDocs into whatever python version you are run
 ### Method 2: Install using a Python virtual environment
 This method uses a built in feature of Python called a *virtual environment*, which allows you to contain what you install to python inside of a single folder on your PC, so that is does not interfere with anything else on your computer, allowing you to cleanly delete the folder when done and remove all trace of what you installed (in this case, MkDocs). 
 
-1. Using git or the Github Desktop app, clone your fork of the wiki to your desktop. 
+1. Using git or the GitHub Desktop app, clone your fork of the wiki to your desktop. 
 1. You should now have a `flipper-community-wiki` folder. 
 1. open up Powershell or your preferred terminal and `cd` inside of this folder. 
 1. run `python -m venv venv` and wait for this to complete. 
@@ -104,7 +104,7 @@ When done, you can close out the virtual environment by typing `deactivate` in y
 
 
 ## Adding New Pages
-1. [Fork this Github repo and clone your copy to your PC](pull-request-guide.md). 
+1. [Fork this GitHub repo and clone your copy to your PC](pull-request-guide.md). 
 1. Optionally install mkdocs using the above instructions if you don't have it to preview pages (strongly recommended)
 1. Enter the `flip-wiki/docs` folder
 1. Create whatever doc files you want in named `.md` files.

--- a/flip-wiki/docs/arcadecards.md
+++ b/flip-wiki/docs/arcadecards.md
@@ -2,19 +2,23 @@
 !!! warning "**WARNING**"
     *You __should not__ be using your Flipper Zero to emulate your arcade data card.*
 
-The five main arcade data cards are:
+The five main arcade data cards currently in use are:
 
-| Company | Card | Chip | FeliCa<br>AIC | Notable<br>Games |
+| Company | Card | Chip | FeliCa<br>AIC | Supported<br>Games |
 | ----------- | ---------- | ------------ | ----------- | ----------- |
-| **Andamiro**<br>*AM* | [AM.PASS](https://am-pass.net/) | ICODE SLI<br>ICODE SLIX<br>ICODE SLIX2 | - | [Chrono Circle](https://chrono-circle.com/)<br>[PIU](https://piugame.com/) |
-| **Bandai Namco**<br>*BN* | [Bandai Namco Passport](https://banapass.net/setlocale/en/)<br>*Banapass / BNP* | MIFARE Classic | X | [Taiko](https://donderhiroba.jp/login.php)<br>[WM6RR](https://wanganmaxi-official.com/wanganmaxi6rr/en/) |
-| **Konami** | [e-amusement pass](https://p.eagate.573.jp/index.html)<br>*e-amuse / eap*| ICODE SLI | X | [DDR](https://p.eagate.573.jp/game/ddr/ddrworld/top/index.html)<br>[SDVX](https://p.eagate.573.jp/game/sdvx/vi/) |
-| **Sega** | [Aime](https://my-aime.net/en/) | MIFARE Classic | X | [IDAC](https://initiald.sega.jp/inidac/)<br>[maimai](https://maimai.sega.com/) |
-| **Taito** | [NESiCA](https://nesica.net/) | MIFARE Ultralight | X | [MUSiCDiVER](https://musicdiver.jp/index.html)<br>[SF6TA](https://sf6ta.jp/) |
+| **Andamiro**<br>*AM* | [AM.PASS](https://am-pass.net/) | ICODE SLI<br>ICODE SLIX<br>ICODE SLIX2 | - | [Pump It Up](https://piugame.com/) |
+| **Bandai Namco**<br>*BN* | [Bandai Namco Passport](https://banapass.net/setlocale/en/)<br>*Banapass / BNP* | MIFARE Classic | X | [太鼓の達人](https://donderhiroba.jp/login.php)<br>*Taiko no Tatsujin*<br>[湾岸マキシ](https://wanganmaxi-official.com/wanganmaxi6rr/en/)<br>*Wangan Maxi* |
+| **Konami** | [e-amusement pass](https://p.eagate.573.jp/index.html)<br>*e-amuse / eap*| ICODE SLI | X | [DanceDanceRevolution](https://p.eagate.573.jp/game/ddr/ddrworld/top/index.html)<br>[SOUND VOLTEX](https://p.eagate.573.jp/game/sdvx/vi/) |
+| **Sega** | [Aime](https://my-aime.net/en/) | MIFARE Classic | X | [CHUNITHM](https://chunithm.sega.com)<br>[頭文字D](https://initiald.sega.jp/inidac/)<br>*InitialD*<br>[maimai](https://maimai.sega.com/) |
+| **Taito** | [NESiCA](https://nesica.net/) | MIFARE Ultralight | X | [MUSIC DIVER](https://musicdiver.jp/index.html)<br>[STREET FIGHTER](https://sf6ta.jp/) |
 
-The Flipper Zero includes the `Sega Aime` and `Bandai Namco Passport` access keys in the system dictionary as of OFW 0.98.2, with the `Sega Aime` parser for revealing the corresponding access code.
+The Flipper Zero includes the MFC `Sega Aime` and `Bandai Namco Passport` access keys in the system dictionary as of OFW 0.98.2.
 
-The latter four companies have FeliCa card variants endorsed with the `Amusement IC Card [AIC]` logo, with the Flipper Zero having expanded its `FeliCa` emulation support as of OFW 0.103.1, and emulation compatibility is listed below:
+The `Sega Aime` parser reveals its access code.
+
+The latter four companies have FeliCa card variants endorsed with the `Amusement IC Card [AIC]` logo.
+
+The Flipper Zero expanded its `FeliCa` emulation support as of OFW 0.103.1.
 
 ### Arcade Data Card Emulation Compatibility
 | Card | Chip | AM | BN | Konami | Sega | Taito |
@@ -27,19 +31,26 @@ The latter four companies have FeliCa card variants endorsed with the `Amusement
 | NESiCA | MFU | - | - | - | - | X |
 
 ### Arcade Data Card Emulation Compatibility Notes
-- If FeliCa emulation does not work, you may need to:
+- If FeliCa emulation does not work, you firstly need to:
     1. Back up your microSD card;
-    1. Synchronise your Flipper Zero with your Mobile App;
+    1. Reboot your Flipper Zero;
+    1. Synchronise your Flipper Zero with your [Mobile App / qFlipper](https://flipperzero.one/update);
+    1. Update to the latest OFW Version; then,
+    1. Update any installed Apps;
+- If FeliCa emulation *still* does not work, you then need to:       
+    1. Back up your microSD card;
+    1. Format your microSD card;
     1. Factory reset your Flipper Zero;
-    1. Format your microSD card; then,
-    1. Update to the latest OFW Version.
+    1. Re-connect your Flipper to your [Mobile App / qFlipper](https://flipperzero.one/update);
+    1. Re-update to the latest OFW Version; then,
+    1. Re-install any external Apps.
 - There is an issue that prevents the Flipper Zero from emulating:
     1. FeliCa `Amusement IC Cards` on `Sega` games;
     1. ICODE SLI `e-amusement pass` cards on `Konami` games;
     1. MFC `Aime` cards on `Sega` games; and,
     1. MFC `Bandai Namco Passport` cards on `Sega` games.
 - Emulation compatibility cannot be tested for `Taito` games without further assistance from Members located within Japan.
-- The ICODE SLI `e-amusement pass` cards are not compatible with `Andamiro` games.
+- The ICODE SLI `e-amusement pass` cards are not compatible with `Andamiro` games *and vice versa*.
 
 ## Arcade Payment Cards
 !!! warning "**WARNING**"

--- a/flip-wiki/docs/contributing.md
+++ b/flip-wiki/docs/contributing.md
@@ -5,7 +5,7 @@ The underlying Github repo can be [located here](https://github.com/Flipper-Comm
 ## Contributer Guidelines
 The following guidelines should be kept in mind when submitting changes:
 
-- This wiki may grow to support other Flipper items beyond just the Flipper zero, so be precise about which device you reference. 
+- This wiki may grow to support other Flipper items beyond just the Flipper Zero, so be precise about which device you reference. 
 - Our audience is international based, so use clear and precise language, avoiding slang or acronyms without explanation.
 - Do not provide guides to facilitate illegal activity.
     - This includes but is not restricted to: jamming, illegal radio transmitting, defeating regional frequency locks, and fraud

--- a/flip-wiki/docs/mifareclassic.md
+++ b/flip-wiki/docs/mifareclassic.md
@@ -3,15 +3,15 @@ Here are the steps to follow in order to read your cards. Your goal is to find a
 
 ## Prerequisites
 
-You must update your firmware ([how-to](https://docs.flipper.net/basics/firmware-update)) to the latest official firmware (OFW) release (version 1.1.2 or later). You must also install the [MFKey app](https://lab.flipper.net/apps/mfkey) (version 3.0 or later).
+You must update your firmware ([**how-to**](https://docs.flipper.net/basics/firmware-update)) to the latest official firmware (OFW) release (version 1.1.2 or later). You must also install the [**MFKey app**](https://lab.flipper.net/apps/mfkey) (version 3.0 or later).
 
 
-## Reading the card
+## Reading the Card
 
 Steps:
 
-1. **Read from NFC app**: Try to scan your MIFARE Classic card with NFC -> Read. It will try a dictionary (and KDF) attack of default keys to unlock your card, as well as any keys you may have found through other methods. If it finds 32/32 keys (or 80/80) with 16/16 sectors (or 40/40), congratulations and [proceed to "Emulation"](mifareclassic.md#emulation). If not, wait for nonce collection to complete (be patient!) and continue to step 2.
-2. **Crack with MFKey app**: Navigate to Main Menu -> Applications -> NFC -> MFKey, press OK to run. Do not interrupt the cracking process, it may take a while! When the cracking process is complete, the number of new user keys (or candidate keys) that are found will be shown. If more than zero keys are found, return to step 1 and repeat the process.
+1. **Read From NFC App**:<br>Try to scan your MIFARE Classic card with NFC -> Read. It will try a dictionary (and KDF) attack of default keys to unlock your card, as well as any keys you may have found through other methods. If it finds 32/32 keys (or 80/80) with 16/16 sectors (or 40/40), congratulations and [**proceed to "Emulation"**](mifareclassic.md#emulation). If not, wait for nonce collection to complete (be patient!) and continue to step 2.
+2. **Crack With MFKey App**:<br>Navigate to Main Menu -> Applications -> NFC -> MFKey, press OK to run. Do not interrupt the cracking process, it may take a while! When the cracking process is complete, the number of new user keys (or candidate keys) that are found will be shown. If more than zero keys are found, return to step 1 and repeat the process.
 
 ## Troubleshooting
 
@@ -19,14 +19,14 @@ Q: **I have zero keys, how do I find more?**
 
 A: You can find more keys from the card reader (the same one you would normally tap your card against) using the Mfkey32 attack. Navigate to NFC -> Extract MF Keys and hold the Flipper Zero up to the reader. If the reader unlocks during this process, it is using the UID of the card and is highly insecure. Otherwise, it'll collect "nonces" from the reader. You can crack the nonces to find the reader keys by running MFKey following Extract MF Keys (navigate to Main Menu -> Applications -> NFC -> MFKey, press OK to run).
 
-When the cracking process is complete, the number of new user keys (or candidate keys) that are found will be shown. If more than zero keys are found, return to step 1 of [Reading the card](#reading-the-card) and repeat the process.
+When the cracking process is complete, the number of new user keys (or candidate keys) that are found will be shown. If more than zero keys are found, return to step 1 of [**Reading the Card**](#reading-the-card) and repeat the process.
 
 Q: **When I read the card in the NFC app, it says "(Hard)" at the top, and when I use MFKey it errors with "No nonces found". How do I find new keys?**
 
 A: You need to perform a Hardnested attack using the nonces your Flipper Zero saved when reading the card. You have two options:
 
-* Follow the guide to run HardnestedRecovery [here](https://github.com/noproto/HardnestedRecovery#usage).
-* Upload the .nested.log from your device (nfc/.nested.log on your SD card) to [this website](https://flipperzero.club/hardnested/) and copy any found keys back to your user dictionary (nfc/assets/mf_classic_dict_user.nfc on your SD card). You can also manually add new keys on the Flipper by navigating to Main Menu -> NFC -> Extra Actions -> MIFARE Classic Keys -> Add.
+* Follow the guide to run HardnestedRecovery [**here**](https://github.com/noproto/HardnestedRecovery#usage).
+* Upload the .nested.log from your device (nfc/.nested.log on your SD card) to [**this website**](https://flipperzero.club/hardnested/) and copy any found keys back to your user dictionary (nfc/assets/mf_classic_dict_user.nfc on your SD card). You can also manually add new keys on the Flipper by navigating to Main Menu -> NFC -> Extra Actions -> MIFARE Classic Keys -> Add.
 
 ## Emulation
 
@@ -34,13 +34,16 @@ A: You need to perform a Hardnested attack using the nonces your Flipper Zero sa
 
 Go to NFC -> Saved -> (The name you assigned your card) -> Emulate and hold it up to the reader. Try various angles to find the correct positioning.
 
-Even if you have all of the keys and try to emulate your card, you may find the reader still does not accept the emulated card (<https://flp.wiki/nfc/mfc/emulation/>). This is often a timing issue (slow emulation on the Flipper Zero). You have three options:
+Even if you have all of the keys and try to emulate your card, you may find the reader still does not accept the emulated card (**<https://flp.wiki/nfc/mfc/emulation/>**). This is often a timing issue (slow emulation on the Flipper Zero). You have three options:
 
 * Update your Flipper Zero to the latest firmware (0.94.0 or above). Flipper Devices rewrote the NFC stack, which improved MIFARE Classic dictionary attacks and emulation.
 * Purchase a special kind of MIFARE Classic card called a magic card to clone the data onto a physical card. Magic cards are more likely to be recognized by the card reader, however some readers may be programmed to detect magic cards. To find shops to purchase magic cards from, search for the magic card you need (ensure the listing mentions the term "UID changeable"):
     - 4 byte UID (e.g. `AA BB CC DD`): Gen1a Magic Card (💲), Gen2 Magic Card - 4 byte UID variant (💲💲)
     - 7 byte UID (e.g. `AA BB CC DD EE FF 00`): Gen2 Magic Card - 7 byte UID variant (💲💲), Gen4/Ultimate Magic Card (💲💲💲)
 
-    Follow the official guide to write the card data to a magic card: (<https://docs.flipper.net/nfc/magic-cards>).
+    Follow the official guide to write the card data to a magic card: (**<https://docs.flipper.net/nfc/magic-cards>**).
 
-* If you have a spare identical MIFARE Classic card (1K for 1K, 4K for 4K, EV1 for EV1, etc.), have all of the keys to the spare card, and the access conditions on the spare card allow: you can duplicate the data from the initial card to the spare card and it could possibly work (if the reader is indifferent to the UID of the card, and if the keys are *diversified* - you will need the diversified keys from the reader using Mfkey32/KDF provided they are not already present on the card). ⚠️ IMPORTANT: Save the data stored on the spare card before overwriting it, otherwise it will be irrecoverably erased. This is less reliable than using a magic card, but an option if you are unable to obtain a magic card.
+* If you have a spare identical MIFARE Classic card (1K for 1K, 4K for 4K, EV1 for EV1, etc.), have all of the keys to the spare card, and the access conditions on the spare card allow: you can duplicate the data from the initial card to the spare card and it could possibly work (if the reader is indifferent to the UID of the card, and if the keys are *diversified* - you will need the diversified keys from the reader using Mfkey32/KDF provided they are not already present on the card).
+
+!!! warning "**WARNING**"
+    *Save the data stored on the spare card before overwriting it, otherwise it will be irrecoverably erased. This is less reliable than using a magic card, but an option if you are unable to obtain a magic card.*

--- a/flip-wiki/docs/nfc-overview.md
+++ b/flip-wiki/docs/nfc-overview.md
@@ -3,11 +3,23 @@
 The Flipper Zero can read and emulate a number of NFC tags. Keep in mind however that NFC RFID technology is a complex topic with *many* tag types of varying security, and not all can be read by the device. 
 The official [Flipper Zero docs](https://docs.flipper.net/nfc/read) detail what types of cards can and cannot be used with the device. Additionally, while the device can read these cards, not all of them can be saved or emulated due to the higher security design of select NFC formats. 
 
-
-
+---
 ## MIFARE Classic
-- See our [**MIFARE Classic guide**](mifareclassic.md)
-- For making copies of mifare classic, refer to the [documentation](https://docs.flipper.net/nfc/magic-cards)
+- See our [**MIFARE Classic guide**](mifareclassic.md).
+- For making copies of MIFARE Classic, refer to the [documentation](https://docs.flipper.net/nfc/magic-cards).
 
-## HID Seos / NXP MIFARE DESFire
-- Standard keyed can be read with [Seader](https://lab.flipper.net/apps/seader)
+---
+## MIFARE DESFire
+- Use the `NFC` App to read the DESFire credential.
+
+---
+## HID iCLASS
+- Standard-keyed iCLASS can be read via [PicoPass](https://lab.flipper.net/apps/picopass).
+- Certain elite-keyed iCLASS can also be read via `PicoPass` via the `Elite System Dictionary`.
+- Some iCLASS SE credentials can be read via [Seader](https://lab.flipper.net/apps/seader).
+  - *You will require a compatible NARD and SAM to use the `Seader` app.*
+
+---
+## HID SEOS
+- Standard-keyed Seos can be read with [Seader](https://lab.flipper.net/apps/seader).
+   - *You will require a compatible NARD and SAM to use the `Seader` app.*

--- a/flip-wiki/docs/nfc-overview.md
+++ b/flip-wiki/docs/nfc-overview.md
@@ -1,25 +1,38 @@
 # NFC Overview
 
-The Flipper Zero can read and emulate a number of NFC tags. Keep in mind however that NFC RFID technology is a complex topic with *many* tag types of varying security, and not all can be read by the device. 
-The official [Flipper Zero docs](https://docs.flipper.net/nfc/read) detail what types of cards can and cannot be used with the device. Additionally, while the device can read these cards, not all of them can be saved or emulated due to the higher security design of select NFC formats. 
-
----
-## MIFARE Classic
-- See our [**MIFARE Classic guide**](mifareclassic.md).
-- For making copies of MIFARE Classic, refer to the [documentation](https://docs.flipper.net/nfc/magic-cards).
-
----
-## MIFARE DESFire
-- Use the `NFC` App to read the DESFire credential.
+The official [**Flipper Zero NFC docs**](https://docs.flipper.net/nfc) detail what type of NFC tags can be used with the Flipper Zero, and whether it can:
+- Read the NFC tag;
+- Write to the NFC tag;
+- Save the NFC tag as an `.nfc` file; and/or,
+- Emulate the saved NFC tag.
 
 ---
 ## HID iCLASS
-- Standard-keyed iCLASS can be read via [PicoPass](https://lab.flipper.net/apps/picopass).
-- Certain elite-keyed iCLASS can also be read via `PicoPass` via the `Elite System Dictionary`.
-- Some iCLASS SE credentials can be read via [Seader](https://lab.flipper.net/apps/seader).
-  - *You will require a compatible NARD and SAM to use the `Seader` app.*
+- Use [**PicoPass**](https://lab.flipper.net/apps/picopass) to read standard-keyed iCLASS and some elite-keyed iCLASS.
+- Use [**Seader**](https://lab.flipper.net/apps/seader) *with a compatible NARD and SAM* to read some iCLASS SE credentials.
 
 ---
-## HID SEOS
-- Standard-keyed Seos can be read with [Seader](https://lab.flipper.net/apps/seader).
-   - *You will require a compatible NARD and SAM to use the `Seader` app.*
+## HID Seos
+- Use [**Seader**](https://lab.flipper.net/apps/seader) *with a compatible NARD and SAM* to read standard-keyed Seos.
+
+---
+## FeliCa
+- *Also known as Felicity Card*
+- If applicable:
+  - See our [**Arcade guide**](arcadecards.md).
+  - See our [**Public Transport guide**](publictransport.md).
+
+---
+## NXP MIFARE Classic
+- See our [**MIFARE Classic guide**](mifareclassic.md).
+  - See [**Flipper Zero's Magic Cards doc**](https://docs.flipper.net/nfc/magic-cards) for making copies of a MIFARE Classic.
+- If applicable:
+  - See our [**Arcade guide**](arcadecards.md).
+  - See our [**Public Transport guide**](publictransport.md).
+
+---
+## NXP MIFARE DESFire / NXP MIFARE Plus / NXP MIFARE Ultralight
+- Use the `NFC` App to read basic information about a MIFARE.
+- If applicable:
+  - See our [**Arcade guide**](arcadecards.md).
+  - See our [**Public Transport guide**](publictransport.md).

--- a/flip-wiki/docs/nfc-overview.md
+++ b/flip-wiki/docs/nfc-overview.md
@@ -5,9 +5,9 @@ The official [Flipper Zero docs](https://docs.flipper.net/nfc/read) detail what 
 
 
 
-## Mifare Classic
+## MIFARE Classic
 - See our [**MIFARE Classic guide**](mifareclassic.md)
 - For making copies of mifare classic, refer to the [documentation](https://docs.flipper.net/nfc/magic-cards)
 
-## HID Seos/Desfire
+## HID Seos / NXP MIFARE DESFire
 - Standard keyed can be read with [Seader](https://lab.flipper.net/apps/seader)

--- a/flip-wiki/docs/publictransport.md
+++ b/flip-wiki/docs/publictransport.md
@@ -10,7 +10,7 @@
 
 ## FeliCa
 If you have a Japan Rail IC Card, then you can use either `MetroDroid` or the Android version of `NFC TagInfo by NXP` to view some information relating to the card.
-`Metroflip` is currently adding support for Japan Rail IC Cards, and this page will be updated when that is released.
+`Metroflip` is currently adding support for HKG Octopus and Japan Rail IC Cards, and this page will be updated when `Metroflip`'s author releases that update.
 
 ## MIFARE Classic
 If your transit agency is using MIFARE Classic, then follow [the MIFARE Classic guide](mifareclassic.md).

--- a/flip-wiki/docs/publictransport.md
+++ b/flip-wiki/docs/publictransport.md
@@ -1,28 +1,37 @@
 # Public Transport Cards
-**<p style="text-align:center;color:red">NOTE: The below information is for educational purposes only, and is <b><u>NOT</u></b> designed to facilitate fare evasion.</p>**
-
+!!! warning "**WARNING**"
+    *The below information is for educational purposes only, and is* ***__NOT__*** *designed to facilitate fare evasion.*
 
 ## Resources
 - [MetroDroid](https://github.com/metrodroid/metrodroid)
-- [NXP TagInfo by NXP: Google Play](https://play.google.com/store/apps/details?id=com.nxp.taginfolite)
-- [NXP TagInfo by NXP: App Store](https://apps.apple.com/us/app/nfc-taginfo-by-nxp/id1246143596)
+- [Metroflip](https://lab.flipper.net/apps/metroflip)
+- [NFC TagInfo by NXP: Google Play](https://play.google.com/store/apps/details?id=com.nxp.taginfolite)
+- [NFC TagInfo by NXP: App Store](https://apps.apple.com/us/app/nfc-taginfo-by-nxp/id1246143596)
+
+## FeliCa
+If you have a Japan Rail IC Card, then you can use either `MetroDroid` or the Android version of `NFC TagInfo by NXP` to view some information relating to the card.
+`Metroflip` is currently adding support for Japan Rail IC Cards, and this page will be updated when that is released.
 
 ## MIFARE Classic
 If your transit agency is using MIFARE Classic, then follow [the MIFARE Classic guide](mifareclassic.md).
 
 ## MIFARE DESFire
-If your transit agency is using MIFARE DESFire, then use either your Flipper Zero or the `MetroDroid` app to see if your transit card has any unlocked applications/files that reveal information such as:
-- Card name;
-- Card number;
-- Fare type;
-- Product type;
-- Machine code;
-- Current balance;
-- Last/recent transaction date[s]/time[s];
-- Vehicle type;
-- Weekly journeys;
-- Transaction counter
+If your transit agency is using MIFARE DESFire, then use either your Flipper Zero's `Metroflip` and `NFC` apps, and the `MetroDroid` app to see if your transit card has any unlocked applications/files that reveal information such as:
+| Category            | Example 1           | Example 2           | Example 3             |  
+| ------------------- | ------------------- |-------------------- |---------------------- |
+| Card Name           | Opal (SYD)          | myki (MEL)          | metroCARD (ADL)       |
+| Card Number         | 3085 2212 3456 7890 | 3 08425 1337 4206 9 | 01-141 2345 6789 0123 |
+| Fare Type           | Full Fare           |                     | Regular               |
+| Transaction Type    | Tap off             |                     |                       |
+| Current Balance     | $10.00              |                     |                       |
+| Last Txn Date/Time  | 31 Dec 24 at 23:59  |                     |                       |
+| Vehicle Yype        | Bus                 |                     |                       |
+| Weekly Journeys     | 1                   |                     |                       |
+| Transaction Counter | 42                  |                     |                       |
+| Issue Date          |                     |                     | 1 Jan 25              |
+| Expiry Date         |                     |                     | 30 Jun 45             |
+| Machine Code        |                     |                     | 619                   |
 
-If the card is fully-locked, then the only valuable piece of information would be the six hexadecimal Application IDs; these may be found by looking at the Flipper Zero `.nfc` file or by scanning your card via the `NXP TagInfo by NXP` app.
+If the card is fully-locked, then the only valuable piece of information would be the six hexadecimal Application IDs; these may be found by looking at the Flipper Zero `.nfc` file or by scanning your card via the `NFC TagInfo by NXP` app.
 
 Feel free to discuss public transport in [#nfc](https://discord.com/channels/740930220399525928/95442271613867625).

--- a/pull-request-guide.md
+++ b/pull-request-guide.md
@@ -1,26 +1,26 @@
 # Pull Request Guide
-This guide seeks to provide some information for those who may not have much experience with Github, git, or pull requests but wish to add to the wiki.
+This guide seeks to provide some information for those who may not have much experience with GitHub, git, or pull requests but wish to add to the wiki.
 Instructions are intended to be followed on a personal computer. 
 
 ## Prerequisites
 To make a pull request, you'll need the following items:
 
 - An installed copy of [Git](https://git-scm.com/downloads)
-- A Github account that you have created and signed in to
+- A GitHub account that you have created and signed in to
 
 ## Pull Request Process
 Below is the general workflow that a pull request requires:
 
-1. [Fork the Github repository](#forking-the-github-repository)
+1. [Fork the GitHub repository](#forking-the-github-repository)
 1. [Clone to your local computer](#cloning-to-your-pc)
 1. [Make your changes](#make-your-changes)
-1. [Use git to commit changes back up to Github](#commit-changes-back-to-github)
-1. [Create a pull request on Github](#create-a-pull-request)
+1. [Use git to commit changes back up to GitHub](#commit-changes-back-to-github)
+1. [Create a pull request on GitHub](#create-a-pull-request)
 
 
-### Forking the Github Repository
+### Forking the GitHub Repository
 
-After one has signed into their Github account, you should now see a `Fork` button at the top right area on the [Flipper Community Wiki](https://github.com/Flipper-Community/flipper-community-wiki). 
+After one has signed into their GitHub account, you should now see a `Fork` button at the top right area on the [Flipper Community Wiki](https://github.com/Flipper-Community/flipper-community-wiki). 
 To fork the Flipper Community Wiki: do the following:
 
 1. Click the `Fork` button
@@ -32,11 +32,11 @@ To fork the Flipper Community Wiki: do the following:
 You should now have your own copy of the wiki in your own repository to change as you like. 
 
 ### Cloning to your PC
-1. Browse to your profile on Github
+1. Browse to your profile on GitHub
 1. Click **Repositories**
 1. Find the wiki fork you created in the [forking step](#forking-the-github-repository) and click to navigate to it
 1. Click the green `Code` button, then choose **HTTPS**
-1. Copy the URL that Github provided
+1. Copy the URL that GitHub provided
 1. On your PC, decide on a easily accessible folder that you'd like to copy files into (I.E. a folder created on your desktop or something)
 1. Open up a terminal on your PC (typically this will be Powershell or Bash depending on OS)
 1. `cd` into the easily accessible folder you created in the earlier step. 
@@ -48,7 +48,7 @@ You are now ready to add to the wiki.
 Refer to the [main readme for getting mkdocs set up and testing your changes](README.md).
 Then return to this guide once you have your changes in place. 
 
-### Commit changes back to Github
+### Commit changes back to GitHub
 Once you are done making changes to the wiki, we will then need to add our changes to git and create a commit to store them. 
 We will also only want to add files we have added or changed, and nothing else. 
 
@@ -60,15 +60,15 @@ We will also only want to add files we have added or changed, and nothing else.
 1. If everything looks correct, we are now ready to commit this. 
 1. Run `git commit -m "Your message here providing a short description of changes made"` to create a commit.
     - if this is your first time running git, it will prompt you about setting your name and email. You will need to set these to whatever you like (doesn't have to be real info if you do not desire it to be so). Just run the commands it provides to set your email and name, the re-run the commit command above. 
-1. We can now push this up to Github by running `git push origin master`
-    - This should prompt git to ask you for your Github login username and password if it is your first time. Go ahead and enter this in.
+1. We can now push this up to GitHub by running `git push origin master`
+    - This should prompt git to ask you for your GitHub login username and password if it is your first time. Go ahead and enter this in.
 1. If all goes well, the command should complete without raising any errors.
-1. Verify your files are now on Github under your wiki repository on the website.
+1. Verify your files are now on GitHub under your wiki repository on the website.
 
 ### Create a Pull Request
-After making any needed commits to Github, you are now ready to create a Pull Request on the Flipper Community Wiki. 
+After making any needed commits to GitHub, you are now ready to create a Pull Request on the Flipper Community Wiki. 
 
-1. Navigate to your copy of the community wiki on Github
+1. Navigate to your copy of the community wiki on GitHub
 1. In the top left area, click the **Pull requests** tab
 1. On the right upper side, click **New pull request**
 1. At the top of this page, you will have an area that describes how the data to flow


### PR DESCRIPTION
## Sitewide
- Changed `Github` to `GitHub`.
- Changed `Flipper zero` to `Flipper Zero`.

## `arcadecards.md`
- Updated Table 1's list of compatible games to use their original names *in Japanese*, with English translations below.
- Removed `Chrono Circle` as one of Andamiro's compatible games *because they deprecated the game*.
- Simiplified some other text for clarity.

## `mifareclassic.md`
- Boldfaced all hyperlinks.
- Made minor formatting updates.
- Converted the `IMPORTANT` on the last bullet point to a MKDocs `WARNING` tab.

## `publictransport.md`
- Converted MFDES list to table format.
- Added examples to MFDES table using SYD Opal, MEL myki, and ADL metroCARD as examples.
- Added `Metroflip` as a resource.
- Changed `NXP TagInfo by NXP` to `NFC TagInfo by NXP`.
- Updated Felica Emulation diagnostic instructions.

Many thanks in advance, and kind regards,

-R&Y.