### PR TITLE
R&Y: Boldface and Table Updates to `arcade` and `pt`

### DIFF
--- a/flip-wiki/docs/arcadecards.md
+++ b/flip-wiki/docs/arcadecards.md
@@ -6,11 +6,11 @@ The five main arcade data cards currently in use are:
 
 | Company | Card | Chip | FeliCa<br>AIC | Supported<br>Games |
 | ----------- | ---------- | ------------ | ----------- | ----------- |
-| **Andamiro**<br>*AM* | [AM.PASS](https://am-pass.net/) | ICODE SLI<br>ICODE SLIX<br>ICODE SLIX2 | - | [Pump It Up](https://piugame.com/) |
-| **Bandai Namco**<br>*BN* | [Bandai Namco Passport](https://banapass.net/setlocale/en/)<br>*Banapass / BNP* | MIFARE Classic | X | [太鼓の達人](https://donderhiroba.jp/login.php)<br>*Taiko no Tatsujin*<br>[湾岸マキシ](https://wanganmaxi-official.com/wanganmaxi6rr/en/)<br>*Wangan Maxi* |
-| **Konami** | [e-amusement pass](https://p.eagate.573.jp/index.html)<br>*e-amuse / eap*| ICODE SLI | X | [DanceDanceRevolution](https://p.eagate.573.jp/game/ddr/ddrworld/top/index.html)<br>[SOUND VOLTEX](https://p.eagate.573.jp/game/sdvx/vi/) |
-| **Sega** | [Aime](https://my-aime.net/en/) | MIFARE Classic | X | [CHUNITHM](https://chunithm.sega.com)<br>[頭文字D](https://initiald.sega.jp/inidac/)<br>*InitialD*<br>[maimai](https://maimai.sega.com/) |
-| **Taito** | [NESiCA](https://nesica.net/) | MIFARE Ultralight | X | [MUSIC DIVER](https://musicdiver.jp/index.html)<br>[STREET FIGHTER](https://sf6ta.jp/) |
+| **Andamiro**<br>*AM* | [**AM.PASS**](https://am-pass.net/) | ICODE SLI<br>ICODE SLIX<br>ICODE SLIX2 | - | [**Pump It Up**](https://piugame.com/) |
+| **Bandai Namco**<br>*BN* | [**Bandai Namco Passport**](https://banapass.net/setlocale/en/)<br>*Banapass / BNP* | MIFARE Classic | X | [**太鼓の達人**](https://donderhiroba.jp/login.php)<br>*Taiko no Tatsujin*<br>[**湾岸マキシ**](https://wanganmaxi-official.com/wanganmaxi6rr/en/)<br>*Wangan Maxi* |
+| **Konami** | [**e-amusement pass**](https://p.eagate.573.jp/index.html)<br>*e-amuse / eap*| ICODE SLI | X | [**DanceDanceRevolution**](https://p.eagate.573.jp/game/ddr/ddrworld/top/index.html)<br>[**SOUND VOLTEX**](https://p.eagate.573.jp/game/sdvx/vi/) |
+| **Sega** | [**Aime**](https://my-aime.net/en/) | MIFARE Classic | X | [**CHUNITHM**](https://chunithm.sega.com)<br>[**頭文字D**](https://initiald.sega.jp/inidac/)<br>*InitialD*<br>[**maimai**](https://maimai.sega.com/) |
+| **Taito** | [**NESiCA**](https://nesica.net/) | MIFARE Ultralight | X | [**MUSIC DIVER**](https://musicdiver.jp/index.html)<br>[**STREET FIGHTER**](https://sf6ta.jp/) |
 
 The Flipper Zero includes the MFC `Sega Aime` and `Bandai Namco Passport` access keys in the system dictionary as of OFW 0.98.2.
 
@@ -34,14 +34,14 @@ The Flipper Zero expanded its `FeliCa` emulation support as of OFW 0.103.1.
 - If FeliCa emulation does not work, you firstly need to:
     1. Back up your microSD card;
     1. Reboot your Flipper Zero;
-    1. Synchronise your Flipper Zero with your [Mobile App / qFlipper](https://flipperzero.one/update);
+    1. Synchronise your Flipper Zero with your [**Mobile App / qFlipper**](https://flipperzero.one/update);
     1. Update to the latest OFW Version; then,
     1. Update any installed Apps;
 - If FeliCa emulation *still* does not work, you then need to:       
     1. Back up your microSD card;
     1. Format your microSD card;
     1. Factory reset your Flipper Zero;
-    1. Re-connect your Flipper to your [Mobile App / qFlipper](https://flipperzero.one/update);
+    1. Re-connect your Flipper to your [**Mobile App / qFlipper**](https://flipperzero.one/update);
     1. Re-update to the latest OFW Version; then,
     1. Re-install any external Apps.
 - There is an issue that prevents the Flipper Zero from emulating:

--- a/flip-wiki/docs/arcadecards.md
+++ b/flip-wiki/docs/arcadecards.md
@@ -21,14 +21,14 @@ The latter four companies have FeliCa card variants endorsed with the `Amusement
 The Flipper Zero expanded its `FeliCa` emulation support as of OFW 0.103.1.
 
 ### Arcade Data Card Emulation Compatibility
-| Card | Chip | AM | BN | Konami | Sega | Taito |
-| ---------- | ---------- | ---------- | ---------- | ---------- | ---------- | ---------- |
-| AIC | FeliCa | - | X | X | - | - | 
-| Aime | MFC | - | X | - | - | - |
-| AM.PASS | ICODE | X | - | - | - | - |  
-| Banapass | MFC | - | X | - | - | - |
-| e-amuse | ICODE | - | - | - | - | - |
-| NESiCA | MFU | - | - | - | - | X |
+| Card         | Chip   | AM | BN | Konami | Sega | Taito |
+| ------------ | ------ | -- | -- | ------ | ---- | ----- |
+| **AIC**      | FeliCa | -  | X  | X      | -    | -     | 
+| **Aime**     | MFC    | -  | X  | -      | -    | -     |
+| **AM.PASS**  | ICODE  | X  | -  | -      | -    | -     |  
+| **Banapass** | MFC    | -  | X  | -      | -    | -     |
+| **e-amuse**  | ICODE  | -  | -  | -      | -    | -     |
+| **NESiCA**   | MFU    | -  | -  | -      | -    | X     |
 
 ### Arcade Data Card Emulation Compatibility Notes
 - If FeliCa emulation does not work, you firstly need to:

--- a/flip-wiki/docs/publictransport.md
+++ b/flip-wiki/docs/publictransport.md
@@ -18,20 +18,38 @@ If your transit agency is using MIFARE Classic, then follow [**the MIFARE Classi
 ## MIFARE DESFire
 If your transit agency is using MIFARE DESFire, then use either your Flipper Zero's `Metroflip` and `NFC` apps, and the `MetroDroid` app to see if your transit card has any unlocked applications/files that reveal information such as:
 
-| Category            | Example             |  
-| ------------------- | ------------------- |
-| Card Name           | Opal (SYD)          |
-| Card Number         | 3085 2212 3456 7890 |
-| Fare Type           | Full Fare           |
-| Transaction Type    | Tap off             |
-| Current Balance     | $10.00              |
-| Last Txn Date/Time  | 31 Dec 24 at 23:59  |
-| Vehicle Yype        | Bus                 |
-| Weekly Journeys     | 1                   |
-| Transaction Counter | 42                  |
-| Issue Date          | 1 Jan 25            |
-| Expiry Date         | 30 Jun 45           |
-| Machine Code        | 619                 |
+|                         | Example 1           | Example 2             |
+| ----------------------- | ------------------- | --------------------- |
+| **Card Name**           | Opal (SYD)          | metroCARD (ADL)       |
+| **Card Number**         | 3085 2212 3456 7890 | 01-141 2345 6789 0123 | 
+| **Fare Type**           | Full Fare           | Regular               |
+| **Transaction Type**    | Tap off             |                       |
+| **Current Balance**     | $10.00              |                       |
+| **Last Txn Date/Time**  | Wed 5th Jul 4:20pm  | 31 May 2024 at 06:19  |
+| **Balance Updated**     | 12:34 10/01/2025    |                       |
+| **Vehicle Type**        | Bus                 | Bus 1234              |
+| **Weekly Journeys**     | 1                   |                       |
+| **Transaction Counter** | 12                  |                       |
+| **Issue Date**          |                     | 1 January 2024        |
+| **Expiry Date**         |                     | 30 June 2044          |
+| **Machine Code**        |                     | 123                   |
+
+Some transit agencies allow you to scan your card via their mobile app, which may provide additional information such as:
+
+|                        | Example 3                                                    | 
+| ---------------------  | ------------------------------------------------------------ |
+| **Card Name**          | Leap (DUB)                                                   |
+| **App**                | [**Leap Top-Up**](https://about.leapcard.ie/leap-top-up-app) |
+| **Current Balance**    | €0.00                                                        |
+| **Card Number**        | 10123 45678                                                  |
+| **Status**             | Unblocked                                                    |
+| **Auto Top-Up Status** | Disabled (€0.00)                                             |
+| **Issue Date**         | 6/9/23                                                       |
+| **Expiry Date**        | 20/4/43                                                      |
+| **Fare Type**          | Adult                                                        | 
+| **Last Txn Date/Time** | 19 Jun 13:37 Dublin Bus -€2.00                               |
+| **Daily Cap**          | €0.00 / €8.00                                                |
+| **Weekly Cap**         | €0.00 / €32.00                                               |
 
 If the card is fully-locked, then the only valuable piece of information would be the six hexadecimal Application IDs; these may be found by looking at the Flipper Zero `.nfc` file or by scanning your card via the `NFC TagInfo by NXP` app.
 

--- a/flip-wiki/docs/publictransport.md
+++ b/flip-wiki/docs/publictransport.md
@@ -3,35 +3,36 @@
     *The below information is for educational purposes only, and is* ***__NOT__*** *designed to facilitate fare evasion.*
 
 ## Resources
-- [MetroDroid](https://github.com/metrodroid/metrodroid)
-- [Metroflip](https://lab.flipper.net/apps/metroflip)
-- [NFC TagInfo by NXP: Google Play](https://play.google.com/store/apps/details?id=com.nxp.taginfolite)
-- [NFC TagInfo by NXP: App Store](https://apps.apple.com/us/app/nfc-taginfo-by-nxp/id1246143596)
+- [**MetroDroid**](https://github.com/metrodroid/metrodroid)
+- [**Metroflip**](https://lab.flipper.net/apps/metroflip)
+- [**NFC TagInfo by NXP: Google Play**](https://play.google.com/store/apps/details?id=com.nxp.taginfolite)
+- [**NFC TagInfo by NXP: App Store**](https://apps.apple.com/us/app/nfc-taginfo-by-nxp/id1246143596)
 
 ## FeliCa
 If you have a Japan Rail IC Card, then you can use either `MetroDroid` or the Android version of `NFC TagInfo by NXP` to view some information relating to the card.
 `Metroflip` is currently adding support for HKG Octopus and Japan Rail IC Cards, and this page will be updated when `Metroflip`'s author releases that update.
 
 ## MIFARE Classic
-If your transit agency is using MIFARE Classic, then follow [the MIFARE Classic guide](mifareclassic.md).
+If your transit agency is using MIFARE Classic, then follow [**the MIFARE Classic guide**](mifareclassic.md).
 
 ## MIFARE DESFire
 If your transit agency is using MIFARE DESFire, then use either your Flipper Zero's `Metroflip` and `NFC` apps, and the `MetroDroid` app to see if your transit card has any unlocked applications/files that reveal information such as:
-| Category            | Example 1           | Example 2           | Example 3             |  
-| ------------------- | ------------------- |-------------------- |---------------------- |
-| Card Name           | Opal (SYD)          | myki (MEL)          | metroCARD (ADL)       |
-| Card Number         | 3085 2212 3456 7890 | 3 08425 1337 4206 9 | 01-141 2345 6789 0123 |
-| Fare Type           | Full Fare           |                     | Regular               |
-| Transaction Type    | Tap off             |                     |                       |
-| Current Balance     | $10.00              |                     |                       |
-| Last Txn Date/Time  | 31 Dec 24 at 23:59  |                     |                       |
-| Vehicle Yype        | Bus                 |                     |                       |
-| Weekly Journeys     | 1                   |                     |                       |
-| Transaction Counter | 42                  |                     |                       |
-| Issue Date          |                     |                     | 1 Jan 25              |
-| Expiry Date         |                     |                     | 30 Jun 45             |
-| Machine Code        |                     |                     | 619                   |
+
+| Category            | Example             |  
+| ------------------- | ------------------- |
+| Card Name           | Opal (SYD)          |
+| Card Number         | 3085 2212 3456 7890 |
+| Fare Type           | Full Fare           |
+| Transaction Type    | Tap off             |
+| Current Balance     | $10.00              |
+| Last Txn Date/Time  | 31 Dec 24 at 23:59  |
+| Vehicle Yype        | Bus                 |
+| Weekly Journeys     | 1                   |
+| Transaction Counter | 42                  |
+| Issue Date          | 1 Jan 25            |
+| Expiry Date         | 30 Jun 45           |
+| Machine Code        | 619                 |
 
 If the card is fully-locked, then the only valuable piece of information would be the six hexadecimal Application IDs; these may be found by looking at the Flipper Zero `.nfc` file or by scanning your card via the `NFC TagInfo by NXP` app.
 
-Feel free to discuss public transport in [#nfc](https://discord.com/channels/740930220399525928/95442271613867625).
+Feel free to discuss public transport in [**#nfc**](https://discord.com/channels/740930220399525928/95442271613867625).


### PR DESCRIPTION
## Sitewide:
- Boldface on table column headings;
- Boldface on remaining hyperlinks;

## `arcadecards.md`
- Cleaned Table 2's markdown;

## `publictransport.md`
- Added white space above Table 1 for it to correctly parse via MKDocs markdown.
- Removed MEL myki from Table 1 as `Example 2`;
- Updated ADL metroCARD to be `Example 2`;
- Added Table 2 which shows examples of information only accessible via a transit agency's app; and,
  - Added DUB Leap to Table 2 as `Example 3`.
  
  Many thanks in advance, and kind regards,
  
  -R&Y.