### PR TITLE
R&Y: Updates to `arcadecards.md` and `publictransport.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,31 +1,32 @@
 # Flipper Community wiki
-This is the repo for the [Flipper community wiki](https://flipper.wiki).
-If you'd like to contribute to this wiki, you may [fork the repo and offer your changes as a pull request](pull-request-guide.md).
-Please be sure submissions meet the [contribution guidelines](https://flipper.wiki/contributing/).
+This is the repo for the [**Flipper Community Wiki**](https://flipper.wiki).
+
+If you'd like to contribute to this wiki, you may [**fork the Repo and offer your changes as a Pull Request**](pull-request-guide.md).
+Please be sure submissions meet the [**Contribution Guidelines**](https://flipper.wiki/contributing/).
 
 # Technical Info
 This wiki is built using the python based mkdocs builder utilizing the material theme (mkdocs-material).
 
 It is recommended, but not required, that contributors looking to add content run the wiki locally to verify formatting behaves as expected before submitting a pull request to verify the content looks as expected and ensure a smooth pull request process.
-To do so, you will need either a copy of [Git](https://git-scm.com/downloads) or the [GitHub client](https://github.com/apps/desktop) installed to your PC. 
+To do so, you will need either a copy of [**Git**](https://git-scm.com/downloads) or the [**GitHub client**](https://github.com/apps/desktop) installed to your PC. 
 
 You will then need to fork this repo using the fork button on this GitHub page to your own GitHub account, clone it to to your PC, make changes, then submit a Pull Request. 
 
-#### If you are unfamiliar with using git and making pull requests on GitHub, see the [Pull Request Guide](pull-request-guide.md)
+#### If you are unfamiliar with using git and making pull requests on GitHub, see the [**Pull Request Guide**](pull-request-guide.md).
 
 # Setup Guide: Running this Wiki Locally
 
 First, clone your forked copy to your local computer so that you can make changes to it.
 Once you have completed that, you can move to setting up MkDocs-Material locally using one of the options below for your platform. 
 
-The [Python virtual environment method](#Method-2-Install-using-a-Python-virtual-environment) is HIGHLY recommended, however not everyone will feel comfortable with using python directly to install things. For that, alternate instructions are provided for convenience. 
+The [**Python virtual environment method**](#Method-2-Install-using-a-Python-virtual-environment) is HIGHLY recommended, however not everyone will feel comfortable with using python directly to install things. For that, alternate instructions are provided for convenience. 
 
 
 ## Operating system install directions
 These options are for those who are less comfortable with messing around with python and would prefer to just install something on their system. 
 
 ### Windows 11
-For this, we will use the awesome tiny [uv](https://astral.sh) utility to manage pulling in stuff from python without needing to install python or risking your existing python setup.
+For this, we will use the awesome tiny [**uv**](https://astral.sh) utility to manage pulling in stuff from python without needing to install python or risking your existing python setup.
 
 1. Open up Powershell
 1. run `winget install astral-sh.uv`
@@ -56,7 +57,7 @@ Once installed, `cd` into the `flipper-community-wiki/flip-wiki` folder and run 
 ----
 
 ### Mac
-MkDocs can be installed via [Brew](https://brew.sh):
+MkDocs can be installed via [**Brew**](https://brew.sh):
 `brew install mkdocs-material`
 
 Once installed, `cd` into the `flipper-community-wiki/flip-wiki` folder and run `mkdocs serve`
@@ -104,11 +105,11 @@ When done, you can close out the virtual environment by typing `deactivate` in y
 
 
 ## Adding New Pages
-1. [Fork this GitHub repo and clone your copy to your PC](pull-request-guide.md). 
+1. [**Fork this GitHub Repo and clone your copy to your PC**](pull-request-guide.md). 
 1. Optionally install mkdocs using the above instructions if you don't have it to preview pages (strongly recommended)
 1. Enter the `flip-wiki/docs` folder
 1. Create whatever doc files you want in named `.md` files.
 1. Once done, add them to the `flip-wiki/mkdocs.yml` towards the bottom under the `Navigation Heirarchy` section, following the pattern of the other `.md` files.
 1. If the preview looks good when using mkdocs to preview them, submit a pull request. 
 
-For more in depth features, see the [MkDocs-material guide](https://squidfunk.github.io/mkdocs-material/reference/)
+For more in depth features, see the [**MkDocs-material guide**](https://squidfunk.github.io/mkdocs-material/reference/).

--- a/flip-wiki/docs/arcadecards.md
+++ b/flip-wiki/docs/arcadecards.md
@@ -12,23 +12,23 @@ The five main arcade data cards currently in use are:
 | **Sega** | [**Aime**](https://my-aime.net/en/) | MIFARE Classic | X | [**CHUNITHM**](https://chunithm.sega.com)<br>[**頭文字D**](https://initiald.sega.jp/inidac/)<br>*InitialD*<br>[**maimai**](https://maimai.sega.com/) |
 | **Taito** | [**NESiCA**](https://nesica.net/) | MIFARE Ultralight | X | [**MUSIC DIVER**](https://musicdiver.jp/index.html)<br>[**STREET FIGHTER**](https://sf6ta.jp/) |
 
-The Flipper Zero includes the MFC `Sega Aime` and `Bandai Namco Passport` access keys in the system dictionary as of OFW 0.98.2.
+The Flipper Zero includes the MFC `Sega Aime` and `Bandai Namco Passport` access keys in the system dictionary as of OFW 0.98.2.<br>The Flipper Zero expanded its `FeliCa` emulation support as of OFW 0.103.1.
 
-The `Sega Aime` parser reveals its access code.
+The `Sega Aime` parser reveals the card's access code.<br>The `Bandai Namco Passport` parser reveals the card's access code *if any*, and will be made available in a future OFW update.
 
 The latter four companies have FeliCa card variants endorsed with the `Amusement IC Card [AIC]` logo.
 
-The Flipper Zero expanded its `FeliCa` emulation support as of OFW 0.103.1.
-
 ### Arcade Data Card Emulation Compatibility
-| Card         | Chip   | AM | BN | Konami | Sega | Taito |
-| ------------ | ------ | -- | -- | ------ | ---- | ----- |
-| **AIC**      | FeliCa | -  | X  | X      | -    | -     | 
-| **Aime**     | MFC    | -  | X  | -      | -    | -     |
-| **AM.PASS**  | ICODE  | X  | -  | -      | -    | -     |  
-| **Banapass** | MFC    | -  | X  | -      | -    | -     |
-| **e-amuse**  | ICODE  | -  | -  | -      | -    | -     |
-| **NESiCA**   | MFU    | -  | -  | -      | -    | X     |
+| Card                 | Chip   | AM | BN | Konami | Sega | Taito |
+| -------------------- | ------ | -- | -- | ------ | ---- | ----- |
+| **AIC**              | FeliCa | -  | X  | X      | -    | -     |
+| **Aime**             | MFC    | -  | X  | -      | -    | -     |
+| **AM.PASS**          | ICODE  | X  | -  | -      | -    | -     |  
+| **Banapass**         | MFC    | -  | X  | -      | -    | -     |
+| **e-amuse**          | ICODE  | -  | -  | -      | -    | -     |
+| **HKG Octopus**      | FeliCa | -  | -  | X      | -    | -     | 
+| **Japan Transit IC** | FeliCa | -  | -  | X      | -    | -     | 
+| **NESiCA**           | MFU    | -  | -  | -      | -    | X     |
 
 ### Arcade Data Card Emulation Compatibility Notes
 - If FeliCa emulation does not work, you firstly need to:
@@ -47,10 +47,14 @@ The Flipper Zero expanded its `FeliCa` emulation support as of OFW 0.103.1.
 - There is an issue that prevents the Flipper Zero from emulating:
     1. FeliCa `Amusement IC Cards` on `Sega` games;
     1. ICODE SLI `e-amusement pass` cards on `Konami` games;
+    1. ICODE SLI/SLIX/SLIX2 `AM.PASS` cards on some `Pump It Up` Cabinets. 
     1. MFC `Aime` cards on `Sega` games; and,
     1. MFC `Bandai Namco Passport` cards on `Sega` games.
 - Emulation compatibility cannot be tested for `Taito` games without further assistance from Members located within Japan.
 - The ICODE SLI `e-amusement pass` cards are not compatible with `Andamiro` games *and vice versa*.
+- Japan Transit IC Cards must be using `FeliCa Standard`.
+- Transport cards are currently only able to be registered for initial play via `DANCERUSH STARDOM` and `SOUND VOLTEX`.
+
 
 ## Arcade Payment Cards
 !!! warning "**WARNING**"
@@ -71,11 +75,13 @@ flowchart TD
 
 ### Mobile Wallet
 [**Dave and Buster's**](https://www.daveandbusters.com/us/en/rewards)<br>Download the D&B Rewards<sup>®️</sup> app and sign up for an account to add your digital Power Card<sup>®️</sup> to your mobile wallet.<br>
+
 1. [**D&B Rewards: App Store**](https://apps.apple.com/us/app/d-b-rewards/id1465097956)
 1. [**D&B Rewards: Google Play**](https://play.google.com/store/apps/details?id=com.DB.playinstore)
 
 
 [**Timezone**](https://portal.timezonegames.com/) / [**Kingpin**](https://portal.kingpinplay.com)<br>Download the Timezone Rewards App and sign up for an account to add your digital Powercard to your mobile wallet.
+
 1. [**Timezone Rewards App: App Store**](https://apps.apple.com/au/app/timezone-fun-app/id1571103348)
 1. [**Timezone Rewards App: Google Play**](https://play.google.com/store/apps/details?id=com.teegloyalty.timezone)
 

--- a/flip-wiki/docs/publictransport.md
+++ b/flip-wiki/docs/publictransport.md
@@ -7,10 +7,13 @@
 - [**Metroflip**](https://lab.flipper.net/apps/metroflip)
 - [**NFC TagInfo by NXP: Google Play**](https://play.google.com/store/apps/details?id=com.nxp.taginfolite)
 - [**NFC TagInfo by NXP: App Store**](https://apps.apple.com/us/app/nfc-taginfo-by-nxp/id1246143596)
+- [**PTDex**](https://github.com/ry4000/ptdex)
 
 ## FeliCa
-If you have a Japan Rail IC Card, then you can use either `MetroDroid` or the Android version of `NFC TagInfo by NXP` to view some information relating to the card.
-`Metroflip` is currently adding support for HKG Octopus and Japan Rail IC Cards, and this page will be updated when `Metroflip`'s author releases that update.
+If you have either a HKG Octopus Card or a Japan Transit IC Card *using FeliCa*, then you can use either `MetroDroid` or the Android version of `NFC TagInfo by NXP` to view some information relating to the card.
+`Metroflip` is currently adding support for HKG Octopus and Japan Transit IC Cards *using FeliCa* in preparation for the next OFW update.
+
+It is also possible to use FeliCa *Standard* cards/tags/fobs/charms as an [**arcade data card**](arcadecards.md) for use on some `Konami` games.
 
 ## MIFARE Classic
 If your transit agency is using MIFARE Classic, then follow [**the MIFARE Classic guide**](mifareclassic.md).
@@ -51,6 +54,8 @@ Some transit agencies allow you to scan your card via their mobile app, which ma
 | **Daily Cap**          | €0.00 / €8.00                                                |
 | **Weekly Cap**         | €0.00 / €32.00                                               |
 
-If the card is fully-locked, then the only valuable piece of information would be the six hexadecimal Application IDs; these may be found by looking at the Flipper Zero `.nfc` file or by scanning your card via the `NFC TagInfo by NXP` app.
+If the card is fully-locked, then the only valuable piece of information would be the six hexadecimal Application IDs; these may be found by looking at the Flipper Zero `.nfc` file or by scanning your card via the `NFC TagInfo by NXP` app. 
+
+Little-endian is used for Flipper Devices' purposes. `Clipper (SFO)`'s AID in big-endian, for example, is `F21190`; converting it to little-endian, it then becomes `0x9011F2`.
 
 Feel free to discuss public transport in [**#nfc**](https://discord.com/channels/740930220399525928/95442271613867625).


### PR DESCRIPTION
### Arcade Cards
1. Added `Bandai Namco Passport` parser information in light of its recent PR merge.
2. Added `HKG Octopus` and *FeliCa Standard* `Japan Transit IC Card`s to the emulation compatibility chart *given they can be used as an arcade data card for `Konami` games if set-up via certain `Konami` games*.
3. Added advice that some Andamiro `Pump It Up` Cabinets may have issues reading emulated `AM.PASS`es.
4. Added a line break in between the `D&B` and `TEEG` Apps text that prevented numbered lists from properly parsing.

### Public Transport
5. Added `PTDex` as a PT resource, with me having added `Flipper Devices' Discord Server` as a `PTDex` call-to-action.
6. Changed `Japan Rail IC Card` to `Japan Transit IC Card` because of Japan's multi-modal nature.
7. Updated `FeliCa` information in light of upcoming `Metroflip` updates.
8. Added information linking back to the Arcade page that says you can use a current `HKG Octopus` or a *FeliCa Standard*  `Japan Transit IC Card` for `Konami` games.
9. Added a sentence on DESFire endians.

Many thanks in advance, and kind regards,

-randy.